### PR TITLE
Added support for mysql timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ For example connecting to localhost with user "bitcoin", password "bitcoin" and 
 bitcoinexchangefh -mysql -mysqldest "bitcoin:bitcoin@localhost:3306" -mysqlschema bcex -instmts subscription.ini
 ```
 
+If you have MySQL 5.6.4+ then you can also use `-mysqlTimestamps` this use timestamp(6) column type instead of varchar(25)
+
 #### CSV
 
 No further setup is required. Just define the output folder path.

--- a/befh/bitcoinexchangefh.py
+++ b/befh/bitcoinexchangefh.py
@@ -43,6 +43,7 @@ def main():
     parser.add_argument('-sqlite', action='store_true', help='Use SQLite database.')
     parser.add_argument('-mysql', action='store_true', help='Use MySQL.')
     parser.add_argument('-zmq', action='store_true', help='Use zmq publisher.')
+    parser.add_argument('-mysqlTimestamps', action='store_true', help='Use timestamp for time colums.')
     parser.add_argument('-mysqldest', action='store', dest='mysqldest',
                         help='MySQL destination. Formatted as <name:pwd@host:port>',
                         default='')
@@ -75,7 +76,7 @@ def main():
         db_clients.append(db_client)
         is_database_defined = True
     if args.mysql:
-        db_client = MysqlClient()
+        db_client = MysqlClient(use_timestamps=args.mysqlTimestamps)
         mysqldest = args.mysqldest
         logon_credential = mysqldest.split('@')[0]
         connection = mysqldest.split('@')[1]

--- a/befh/clients/csv.py
+++ b/befh/clients/csv.py
@@ -31,6 +31,7 @@ class FileClient(DatabaseClient):
             raise Exception("FileClient does not accept empty directory.")
 
         self.file_directory = dir
+        self.name = 'csv'
 
     @staticmethod
     def convert_to(from_str, to_type):

--- a/befh/clients/database.py
+++ b/befh/clients/database.py
@@ -6,6 +6,7 @@ class DatabaseClient:
         """
         Constructor
         """
+        self.name = 'database'
         pass
 
     @classmethod

--- a/befh/clients/kdbplus.py
+++ b/befh/clients/kdbplus.py
@@ -11,6 +11,12 @@ class KdbPlusClient(DatabaseClient):
     """
     Kdb+ Client
     """
+    def __init__(self):
+        """
+        Constructor
+        """
+        self.name = 'kdbplus'
+
     @classmethod
     def parse_condition(cls, condition):
         """

--- a/befh/clients/mysql.py
+++ b/befh/clients/mysql.py
@@ -6,11 +6,13 @@ class MysqlClient(SqlClient):
     """
     Sqlite client
     """
-    def __init__(self):
+    def __init__(self, use_timestamps=False):
         """
         Constructor
         """
         SqlClient.__init__(self)
+        self.use_timestamps = use_timestamps
+        self.name = 'mysql'
 
     def connect(self, **kwargs):
         """

--- a/befh/clients/sql.py
+++ b/befh/clients/sql.py
@@ -16,6 +16,7 @@ class SqlClient(DatabaseClient):
         Constructor
         """
         DatabaseClient.__init__(self)
+        self.name = 'sql'
         self.conn = None
         self.cursor = None
         self.lock = threading.Lock()

--- a/befh/clients/sql_template.py
+++ b/befh/clients/sql_template.py
@@ -12,6 +12,7 @@ class SqlClientTemplate(SqlClient):
         """
         Constructor
         """
+        self.name = 'sql'
         SqlClient.__init__(self)
 
     def connect(self, **kwargs):

--- a/befh/clients/sqlite.py
+++ b/befh/clients/sqlite.py
@@ -17,6 +17,7 @@ class SqliteClient(SqlClient):
         Constructor
         """
         SqlClient.__init__(self)
+        self.name = 'sqllite'
 
     def connect(self, **kwargs):
         """

--- a/befh/clients/zmq.py
+++ b/befh/clients/zmq.py
@@ -18,6 +18,7 @@ class ZmqClient(DatabaseClient):
         self.context = zmq.Context()
         self.conn = self.context.socket(zmq.PUB)
         self.lock = threading.Lock()
+        self.name = 'zmq'
 
     def connect(self, **kwargs):
         """

--- a/befh/exchanges/gateway.py
+++ b/befh/exchanges/gateway.py
@@ -67,7 +67,7 @@ class ExchangeGateway:
         for db_client in db_clients:
             db_client.create(cls.get_snapshot_table_name(),
                              Snapshot.columns(),
-                             Snapshot.types(),
+                             Snapshot.types(db_client=db_client),
                              [0,1], is_ifnotexists=True)
 
     def init_instmt_snapshot_table(self, instmt):
@@ -79,7 +79,7 @@ class ExchangeGateway:
         for db_client in self.db_clients:
             db_client.create(table_name,
                              ['id'] + Snapshot.columns(False),
-                             ['int'] + Snapshot.types(False),
+                             ['int'] + Snapshot.types(False,db_client=db_client),
                              [0], is_ifnotexists=True)
 
             if isinstance(db_client, (MysqlClient, SqliteClient)):
@@ -124,12 +124,13 @@ class ExchangeGateway:
                 if self.is_allowed_snapshot(db_client):
                     db_client.insert(table=self.get_snapshot_table_name(),
                                      columns=Snapshot.columns(),
-                                     types=Snapshot.types(),
+                                     types=Snapshot.types(db_client=db_client),
                                      values=Snapshot.values(instmt.get_exchange_name(),
                                                             instmt.get_instmt_name(),
                                                             instmt.get_l2_depth(),
                                                             Trade() if instmt.get_last_trade() is None else instmt.get_last_trade(),
-                                                            Snapshot.UpdateType.ORDER_BOOK),
+                                                            Snapshot.UpdateType.ORDER_BOOK,
+                                                            db_client=db_client),
                                      primary_key_index=[0,1],
                                      is_orreplace=True,
                                      is_commit=True)
@@ -137,13 +138,14 @@ class ExchangeGateway:
                 if self.is_allowed_instmt_record(db_client):
                     db_client.insert(table=instmt.get_instmt_snapshot_table_name(),
                                           columns=['id'] + Snapshot.columns(False),
-                                          types=['int'] + Snapshot.types(False),
+                                          types=['int'] + Snapshot.types(False,db_client=db_client),
                                           values=[id] +
                                                   Snapshot.values('',
                                                                  '',
                                                                  instmt.get_l2_depth(),
                                                                  Trade() if instmt.get_last_trade() is None else instmt.get_last_trade(),
-                                                                 Snapshot.UpdateType.ORDER_BOOK),
+                                                                 Snapshot.UpdateType.ORDER_BOOK,
+                                                                 db_client=db_client),
                                           is_commit=True)
 
     def insert_trade(self, instmt, trade):
@@ -181,8 +183,9 @@ class ExchangeGateway:
                                                             instmt.get_instmt_name(),
                                                             instmt.get_l2_depth(),
                                                             instmt.get_last_trade(),
-                                                            Snapshot.UpdateType.TRADES),
-                                     types=Snapshot.types(),
+                                                            Snapshot.UpdateType.TRADES,
+                                                            db_client=db_client),
+                                     types=Snapshot.types(db_client=db_client),
                                      primary_key_index=[0,1],
                                      is_orreplace=True,
                                      is_commit=not is_allowed_instmt_record)
@@ -190,11 +193,12 @@ class ExchangeGateway:
                 if is_allowed_instmt_record:
                     db_client.insert(table=instmt.get_instmt_snapshot_table_name(),
                                      columns=['id'] + Snapshot.columns(False),
-                                     types=['int'] + Snapshot.types(False),
+                                     types=['int'] + Snapshot.types(False,db_client=db_client),
                                      values=[id] +
                                             Snapshot.values('',
                                                          '',
                                                          instmt.get_l2_depth(),
                                                          instmt.get_last_trade(),
-                                                         Snapshot.UpdateType.TRADES),
+                                                         Snapshot.UpdateType.TRADES,
+                                                         db_client=db_client),
                                      is_commit=True)


### PR DESCRIPTION
If users of this libs has mysql 5.6.4+ then they are able to store time with microseconds in mysql timestamp data type.

This add support for choosing between varchar(25) and timestamp(6)